### PR TITLE
Fix image download functionality in frontend

### DIFF
--- a/src/composables/useDownload.js
+++ b/src/composables/useDownload.js
@@ -38,9 +38,37 @@ export function useDownload() {
       const response = await downloadSingle(extractionId, imageId)
       filename = extractFilenameFromHeaders(response.headers) || 'download'
       triggerBrowserDownload(response.data, filename)
-      toast.add({ severity: 'success', summary: 'File downloaded', detail: `Filename: ${filename}`, group: 'bc', life: 3000 })
+      toast.add({
+        severity: 'success',
+        summary: 'Image downloaded successfully',
+        detail: `${filename}`,
+        group: 'bc',
+        life: 3000
+      })
     } catch (error) {
-      toast.add({ severity: 'error', summary: 'File download failed', detail: filename ? `Filename: ${filename}` : undefined, group: 'bc', life: 3000 })
+      console.error('Download error:', error)
+
+      // 尝试从 blob 响应中提取错误信息
+      let errorMessage = 'Unknown error'
+      if (error.response?.data instanceof Blob) {
+        try {
+          const text = await error.response.data.text()
+          const errorData = JSON.parse(text)
+          errorMessage = errorData.error || errorMessage
+        } catch (e) {
+          errorMessage = error.message || errorMessage
+        }
+      } else {
+        errorMessage = error.response?.data?.error || error.message || errorMessage
+      }
+
+      toast.add({
+        severity: 'error',
+        summary: 'Download failed',
+        detail: errorMessage,
+        group: 'bc',
+        life: 5000
+      })
     } finally {
       setTimeout(() => {
         downloadSingleImageId.value = ''
@@ -61,9 +89,42 @@ export function useDownload() {
       }
       filename = extractFilenameFromHeaders(response.headers) || 'download'
       triggerBrowserDownload(response.data, filename)
-      toast.add({ severity: 'success', summary: 'File downloaded', detail: `Filename: ${filename}`, group: 'bc', life: 3000 })
+
+      const successMessage = imageIds.length > 1
+        ? `Successfully downloaded ${imageIds.length} images`
+        : 'Image downloaded successfully'
+
+      toast.add({
+        severity: 'success',
+        summary: successMessage,
+        detail: `${filename}`,
+        group: 'bc',
+        life: 3000
+      })
     } catch (error) {
-      toast.add({ severity: 'error', summary: 'File download failed', detail: filename ? `Filename: ${filename}` : undefined, group: 'bc', life: 3000 })
+      console.error('Download error:', error)
+
+      // 尝试从 blob 响应中提取错误信息
+      let errorMessage = 'Unknown error'
+      if (error.response?.data instanceof Blob) {
+        try {
+          const text = await error.response.data.text()
+          const errorData = JSON.parse(text)
+          errorMessage = errorData.error || errorMessage
+        } catch (e) {
+          errorMessage = error.message || errorMessage
+        }
+      } else {
+        errorMessage = error.response?.data?.error || error.message || errorMessage
+      }
+
+      toast.add({
+        severity: 'error',
+        summary: 'Download failed',
+        detail: errorMessage,
+        group: 'bc',
+        life: 5000
+      })
     } finally {
       setTimeout(() => {
         downloadMultipleLoading.value = false


### PR DESCRIPTION
主要改进：
- 增强错误处理：能够从 blob 响应中提取错误信息
- 改进用户反馈：更详细的成功和错误消息
- 显示下载的图片数量
- 延长错误提示显示时间（从3秒改为5秒）
- 添加控制台错误日志以便调试

这些改进确保用户在下载图片时能获得更好的反馈体验。